### PR TITLE
Support referencing subschema types

### DIFF
--- a/jsonschema_typed/types.py
+++ b/jsonschema_typed/types.py
@@ -8,6 +8,6 @@ class JSONSchema(dict):
     """Placeholder for JSON schema TypedDict."""
 
 
-def JSONSchemaBase(schema_path: str) -> Type[dict]:
+def JSONSchemaBase(schema_path: str, schema_ref: str = '#/') -> Type[dict]:
     """Generate a base class for JSON-schema powered TypedDicts."""
     return dict


### PR DESCRIPTION
This adds support for generating the type of a subschema of some larger schema. The subschema is specified using a jsonschema reference.

This is hard to test without some really extensive mocking. I did some manual testing using the following code to get a "TypedContainer" type:
```python
_TypedContainerBase = JSONSchemaBase(
    'yelp_compose.config.types.CONFIG_SCHEMA',
    '#/definitions/container_dict',
)

class TypedContainer(_TypedContainerBase):
    pass
```